### PR TITLE
feat: Implement client side wrapper service

### DIFF
--- a/packages/feathers-automerge/src/index.ts
+++ b/packages/feathers-automerge/src/index.ts
@@ -3,11 +3,12 @@ import { Repo } from '@automerge/automerge-repo'
 import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
 import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb'
 import { Application, NextFunction } from '@feathersjs/feathers'
-import { AutomergeService } from './service.js'
 import { Query, SyncServiceCreate, SyncServiceDocument, SyncServiceInfo } from './utils.js'
+import { serviceWrapper } from './wrapper.js'
 
 export * from './service.js'
 export * from './utils.js'
+export * from './wrapper.js'
 
 export const LOCALSTORAGE_KEY = 'feathers-automerge'
 
@@ -45,28 +46,6 @@ export async function getDocHandle(app: AutomergeClientApp, url: AutomergeUrl): 
   return repo.find<SyncServiceDocument>(url)
 }
 
-export async function initAutomergeServices(app: AutomergeClientApp, url: AutomergeUrl) {
-  app.set('syncHandle', getDocHandle(app, url))
-
-  const handle = await app.get('syncHandle')!
-  const doc = await handle.doc()
-
-  Object.keys(doc).forEach((path) => {
-    if (path !== '__meta') {
-      const { idField, paginate } = doc.__meta[path]
-
-      app.use(
-        path,
-        new AutomergeService(handle, {
-          idField,
-          paginate,
-          path
-        })
-      )
-    }
-  })
-}
-
 export async function syncOffline(app: AutomergeClientApp, payload: SyncServiceCreate) {
   const { syncServicePath } = app.get('syncOptions')
   const info: SyncServiceInfo = await app.service(syncServicePath).create(payload)
@@ -75,7 +54,7 @@ export async function syncOffline(app: AutomergeClientApp, payload: SyncServiceC
     window.localStorage.setItem(LOCALSTORAGE_KEY, info.url)
   }
 
-  await initAutomergeServices(app, info.url)
+  app.set('syncHandle', getDocHandle(app, info.url))
 
   return info
 }
@@ -86,16 +65,6 @@ export async function stopSyncOffline(app: AutomergeClientApp, remove = false) {
   if (!handle) {
     return
   }
-
-  const doc = await handle.doc()
-
-  await Promise.all(
-    Object.keys(doc).map(async (path) => {
-      if (path !== '__meta') {
-        await app.unuse(path)
-      }
-    })
-  )
 
   app.get('repo').delete(handle.documentId)
   app.set('syncHandle', null)
@@ -121,7 +90,7 @@ export function automergeClient(options: AutomergeClientOptions) {
       const url = window.localStorage.getItem(LOCALSTORAGE_KEY)
 
       if (url) {
-        await initAutomergeServices(app, url as AutomergeUrl)
+        app.set('syncHandle', getDocHandle(app, url as AutomergeUrl))
       }
     }
   }
@@ -129,6 +98,7 @@ export function automergeClient(options: AutomergeClientOptions) {
   return function (app: Application) {
     app.set('syncOptions', options)
     app.set('syncHandle', null)
+    app.configure(serviceWrapper)
 
     if (options.authentication) {
       app.on('login', (authResult) => {

--- a/packages/feathers-automerge/src/wrapper.ts
+++ b/packages/feathers-automerge/src/wrapper.ts
@@ -1,34 +1,69 @@
-import { Application } from '@feathersjs/feathers'
+import { Application, Params, Paginated, Service } from '@feathersjs/feathers'
+import { AutomergeClientApp, AutomergeService } from './index.js'
 
 export class WrapperClientService {
-  constructor(name: string) {}
+  public automergeService?: AutomergeService<any>
 
-  async create(data: any): Promise<any> {
-    return this.client.create(data)
+  constructor(
+    public app: AutomergeClientApp,
+    public path: string,
+    public clientService: Service
+  ) {}
+
+  private async route(method: keyof Service, ...args: any[]) {
+    const syncHandle = await this.app.get('syncHandle')
+
+    if (syncHandle === null) {
+      delete this.automergeService
+    }
+
+    if (!this.automergeService && syncHandle !== null) {
+      const doc = syncHandle.doc()
+
+      if (doc[this.path]) {
+        this.automergeService = new AutomergeService(syncHandle, {
+          path: this.path
+        })
+      }
+    }
+
+    if (this.automergeService) {
+      return (this.automergeService as any)[method](...args)
+    }
+
+    return (this.clientService[method] as any)(...args)
   }
 
-  async get(id: string): Promise<any> {
-    return this.client.get(id)
+  async find(params?: Params): Promise<any[] | Paginated<any>> {
+    return this.route('find', params)
   }
 
-  async update(id: string, data: any): Promise<any> {
-    return this.client.update(id, data)
+  async create(data: any, params?: Params): Promise<any> {
+    return this.route('create', data, params)
   }
 
-  async patch(id: string, data: any): Promise<any> {
-    return this.client.patch(id, data)
+  async get(id: string, params?: Params): Promise<any> {
+    return this.route('get', id, params)
   }
 
-  async remove(id: string): Promise<any> {
-    return this.client.remove(id)
+  async update(id: string, data: any, params?: Params): Promise<any> {
+    return this.route('update', id, data, params)
+  }
+
+  async patch(id: string | null, data: any, params?: Params): Promise<any> {
+    return this.route('patch', id, data, params)
+  }
+
+  async remove(id: string | null, params?: Params): Promise<any> {
+    return this.route('remove', id, params)
   }
 }
 
-export function wrapper(app: Application) {
+export function serviceWrapper(app: Application) {
   const originalDefaultService = app.defaultService
 
   app.defaultService = function (this: Application, name: string) {
     const originalService = originalDefaultService.call(this, name)
-    return new WrapperClientService(name, originalService)
+    return new WrapperClientService(this, name, originalService as Service)
   }
 }

--- a/packages/feathers-automerge/test/service.test.ts
+++ b/packages/feathers-automerge/test/service.test.ts
@@ -8,7 +8,7 @@ import { Repo } from '@automerge/automerge-repo'
 import { defineTestSuite } from 'feathers-adapter-vitest'
 
 const testSuite = defineTestSuite({
-  blacklist: ['._get', '._find', '._create', '._update', '._patch', '._remove', '.events']
+  skip: ['._get', '._find', '._create', '._update', '._patch', '._remove', '.events']
 })
 
 describe('@kalisio/feathers-automerge', () => {


### PR DESCRIPTION
This pull request implements a client side default wrapper service that transparently routes between the Automerge service (if offline sync is enabled) or the actual client service.

That way all services can be used the same way as before (without requiring authentication).

Closes https://github.com/kalisio/offline-sync/issues/45